### PR TITLE
fix: update both parties' records when confirmin deliverables

### DIFF
--- a/src/app/transaction/[id]/active/page.tsx
+++ b/src/app/transaction/[id]/active/page.tsx
@@ -418,7 +418,7 @@ export default function TransactionActive({
 
       // Refresh the page to get the latest data from the server
       // This ensures both users see the updated status
-      window.location.reload();
+      // window.location.reload();
     } catch (error) {
       console.error('Error confirming deliverable:', error);
     }


### PR DESCRIPTION
This pull request enhances the deliverable confirmation process for transactions by ensuring that both participants' records are updated in the database when a deliverable is confirmed. It also adds improved logging for debugging and temporarily disables automatic page reloads on the client side.

**Backend improvements to deliverable confirmation:**

* When a user confirms a deliverable, the API now also marks the other participant(s) as confirmed for the same deliverable in the `transaction_participants` table, ensuring data consistency for both parties. ([src/app/api/transaction/[id]/confirm-deliverable/route.tsR80-R103](diffhunk://#diff-324019c5d9fdb6491a0d94243f7dc391c168263b7e73be52e80c13ee1bf52dcaR80-R103))
* Added logging to output the updated participant data and any errors encountered during the update process, aiding in debugging. ([src/app/api/transaction/[id]/confirm-deliverable/route.tsR70-R71](diffhunk://#diff-324019c5d9fdb6491a0d94243f7dc391c168263b7e73be52e80c13ee1bf52dcaR70-R71))

**Frontend change:**

* Temporarily commented out the automatic page reload after confirming a deliverable to prevent unnecessary refreshes and improve user experience. ([src/app/transaction/[id]/active/page.tsxL421-R421](diffhunk://#diff-762204a6cff8d42b0599a73c7e1938093714399bfefb2c153f3b14a56d2085ccL421-R421))