### PR TITLE
feat(escrow): mirror confirmations across participants; fix auto-conf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
+
+## Unreleased
+
+### Added
+
+- Scroll-to-top behavior when navigating steps in the transaction creation flow.
+
+### Changed
+
+- Deliverable status derivation now requires an existing proof before auto-confirmation via oracle verification.
+- UI progress treats `confirmed` deliverables as complete (100%).
+
+### Fixed
+
+- Mirror `item_confirmed` and `payment_confirmed` across both participants for all deliverable types, including `mixed`.
+- Manual and oracle confirmation paths persist mirrored confirmations for both participants.

--- a/src/app/api/oracle/verify/route.ts
+++ b/src/app/api/oracle/verify/route.ts
@@ -121,6 +121,38 @@ export async function POST(request: NextRequest) {
         })
         .eq('id', escrow_id);
 
+      // Mirror confirmations across BOTH participants based on deliverable type
+      if (escrow.transaction_id) {
+        const isItemType = (t: string) =>
+          t === 'item' ||
+          t === 'service' ||
+          t === 'digital' ||
+          t === 'document' ||
+          t === 'product' ||
+          t === 'mixed';
+        const isPaymentType = (t: string) =>
+          t === 'cash' ||
+          t === 'digital_transfer' ||
+          t === 'payment' ||
+          t === 'mixed';
+
+        const updates: Record<string, boolean> = {};
+        if (isItemType(deliverable.type)) updates.item_confirmed = true;
+        if (isPaymentType(deliverable.type)) updates.payment_confirmed = true;
+
+        try {
+          await supabase
+            .from('transaction_participants')
+            .update(updates)
+            .eq('transaction_id', escrow.transaction_id);
+        } catch (e) {
+          console.error(
+            '[Oracle Verify] Error mirroring participant confirmations:',
+            e
+          );
+        }
+      }
+
       // TODO: Submit to blockchain if configured
       // await submitToBlockchain(escrow_id, verificationResult);
     }

--- a/src/app/api/transaction/[id]/status/route.ts
+++ b/src/app/api/transaction/[id]/status/route.ts
@@ -190,19 +190,73 @@ export async function GET(
       oracleVerifications = verifications || [];
     }
 
-    // Calculate deliverable statuses with verifications
+    // Calculate deliverable statuses with verifications (by id)
     const deliverableStatuses =
       escrowData?.deliverables?.map(
-        (deliverable: { id: string; [key: string]: unknown }) => ({
+        (deliverable: { id: string; [key: string]: any }) => ({
           ...deliverable,
-          verification: oracleVerifications.find(() =>
-            escrowData.deliverables?.some(
-              (d: { id: string; [key: string]: unknown }) =>
-                d.id === deliverable.id
-            )
+          verification: oracleVerifications.find(
+            (v: any) => v.deliverable_id === deliverable.id
           ),
         })
       ) || [];
+
+    // Mirror confirmations across both participants and cover all deliverable types
+    if (enrichedParticipants.length > 0) {
+      const isItemType = (t: string) =>
+        t === 'item' ||
+        t === 'service' ||
+        t === 'digital' ||
+        t === 'document' ||
+        t === 'product' ||
+        t === 'mixed';
+      const isPaymentType = (t: string) =>
+        t === 'cash' ||
+        t === 'digital_transfer' ||
+        t === 'payment' ||
+        t === 'mixed';
+
+      const anyParticipantItemConfirmed = enrichedParticipants.some(
+        (p) => p.item_confirmed === true
+      );
+      const anyParticipantPaymentConfirmed = enrichedParticipants.some(
+        (p) => p.payment_confirmed === true
+      );
+
+      const anyItemDeliverableConfirmed = (deliverableStatuses || []).some(
+        (d: any) => isItemType(d.type) && d.status === 'confirmed'
+      );
+      const anyPaymentDeliverableConfirmed = (deliverableStatuses || []).some(
+        (d: any) => isPaymentType(d.type) && d.status === 'confirmed'
+      );
+
+      const unifiedItemConfirmed =
+        anyParticipantItemConfirmed || anyItemDeliverableConfirmed;
+      const unifiedPaymentConfirmed =
+        anyParticipantPaymentConfirmed || anyPaymentDeliverableConfirmed;
+
+      // Apply unified values to in-memory participants for response
+      for (const p of enrichedParticipants) {
+        p.item_confirmed = unifiedItemConfirmed;
+        p.payment_confirmed = unifiedPaymentConfirmed;
+      }
+
+      // Persist to DB if needed: set BOTH participants to unified values
+      try {
+        await supabase
+          .from('transaction_participants')
+          .update({
+            item_confirmed: unifiedItemConfirmed,
+            payment_confirmed: unifiedPaymentConfirmed,
+          })
+          .eq('transaction_id', id);
+      } catch (persistErr) {
+        console.error(
+          '[Status API] Mirror confirmations persist error:',
+          persistErr
+        );
+      }
+    }
 
     console.log(`📊 Status API [${id.slice(0, 8)}]:`, {
       status: transaction.status,

--- a/src/components/transaction/invite/create-transaction-form.tsx
+++ b/src/components/transaction/invite/create-transaction-form.tsx
@@ -104,6 +104,13 @@ export function CreateTransactionForm({
   >([]);
   const [hasConflicts, setHasConflicts] = useState(false);
 
+  // Scroll to top whenever the step changes
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [currentStep]);
+
   // Track which fields are locked individually
   const [fieldLocks, setFieldLocks] = useState({
     item_name: false,


### PR DESCRIPTION
## Summary

Mirror deliverable confirmations across both participants for all deliverable types (including mixed), prevent auto-confirmation without an uploaded proof, and add smooth scroll-to-top when advancing the transaction creation steps. UI treats confirmed deliverables as complete in progress.

Type of change
fix: A bug fix
docs: Documentation only changes

Checklist
My code follows the project's style guidelines (linting/formatting)
I have added tests where relevant and they pass (manual verification for flows in this change)
I have added or updated documentation if necessary (CHANGELOG updated)
I have tested the change locally (dev server/build)

How to test

Start dev server: npm run dev
Transaction creation flow:

1. Navigate between steps with Next/Back → page should smoothly scroll to the top each step.

Deliverables and confirmations:

1. Submit a proof for an item/payment deliverable → status becomes “confirmed”.
2. Allow oracle/manual verification to succeed → both participants should have the relevant confirmation set to true: Item types: item, service, digital, document, product, mixed → item_confirmed = true for both. Payment types: cash, digital_transfer, payment, mixed → payment_confirmed = true for both.
3. Ensure no deliverable gets confirmed if no proof exists, even if verification records exist.

UI progress:
Confirmed deliverables display as 100% progress.

Notes for reviewers
Confirmation mirroring now sets both participant flags; verify no flows depend on asymmetric flags.
Mixed deliverables intentionally set both item_confirmed and payment_confirmed.
No schema changes; changes are confined to APIs and one client component.